### PR TITLE
chore: remove  from Vite config and clean up unused proxy setting

### DIFF
--- a/app/middleware/server.js
+++ b/app/middleware/server.js
@@ -18,11 +18,15 @@ app.use(cors());
 // 👉 API route
 app.get("/api/flickr", async (req, res) => {
   const params = new URLSearchParams({
-    ...req.query,
-    api_key: process.env.VITE_API_KEY,
+    method: req.query.method,
     format: "json",
     nojsoncallback: "1",
+    api_key: process.env.API_KEY,
   });
+
+  if (req.query.username) {
+    params.append("username", req.query.username);
+  }
 
   const url = `https://api.flickr.com/services/rest?${params.toString()}`;
 

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -19,7 +19,6 @@ export default defineConfig(({ mode }) => {
       extensions: [".mjs", ".js", ".ts", ".jsx", ".tsx", ".json", ".vue"],
     },
     server: {
-      allowedHosts: ["flickr-public-photos.onrender.com"],
       port: env.VITE_DEV_PORT,
       proxy: {
         "/api": "http://localhost:3000",


### PR DESCRIPTION
# What’s included

- Final Express middleware integration with Vite in Docker
- Render deployment support with multi-stage Dockerfile
- Proper handling of VITE_API_KEY without exposing it in frontend requests
- Removal of unnecessary allowedHosts in Vite config
- Fix for duplicated fetch call in FlickrUser.vue
- Added uptime ping mechanism to keep Render instance awake

# Notes

All environment-specific configurations have been validated.

Production instance is now live and stable.