### PR TITLE
Fix missing query parameters in Flickr API middleware

### DIFF
--- a/app/middleware/server.js
+++ b/app/middleware/server.js
@@ -18,14 +18,19 @@ app.use(cors());
 // 👉 API route
 app.get("/api/flickr", async (req, res) => {
   const params = new URLSearchParams({
-    method: req.query.method,
     format: "json",
     nojsoncallback: "1",
     api_key: process.env.API_KEY,
   });
 
-  if (req.query.username) {
-    params.append("username", req.query.username);
+  // Parâmetros fixos já definidos
+  const fixedKeys = ["format", "nojsoncallback", "api_key"];
+
+  // Append de todos os outros parâmetros que vierem em req.query
+  for (const [key, value] of Object.entries(req.query)) {
+    if (!fixedKeys.includes(key)) {
+      params.append(key, value);
+    }
   }
 
   const url = `https://api.flickr.com/services/rest?${params.toString()}`;

--- a/app/src/utils/usefulFunctions.js
+++ b/app/src/utils/usefulFunctions.js
@@ -24,12 +24,16 @@ async function fetchData(apiParams) {
   let url = `${API_BASE_URL}/flickr`;
 
   if (apiParams && typeof apiParams === "object") {
-    const queryParams = new URLSearchParams(apiParams).toString();
+    const queryParams = Object.entries(apiParams)
+      .map(([key, value]) => `${key}=${value}`) // Cria a chave-valor sem codificação
+      .join("&");
+
     url += `?${queryParams}`;
   }
 
   const res = await fetch(url);
   const data = await res.json();
+
   return data;
 }
 


### PR DESCRIPTION
This PR fixes an issue where dynamic query parameters such as username or user_id were not being appended to the Flickr API request URL in the Express middleware.

**Impact:**
Flickr API requests now receive all expected parameters, fixing user lookup and public photo retrieval functionality.